### PR TITLE
fix undefined scenario by adding a default value for the farm popup view tabs

### DIFF
--- a/src/features/mines/MineListItemDetails.tsx
+++ b/src/features/mines/MineListItemDetails.tsx
@@ -27,9 +27,10 @@ const Context = createContext<MineListItemDetailsModal | undefined>(undefined)
 // @ts-ignore TYPE NEEDS FIXING
 const MineListItemDetails = ({ farm, onDismiss }) => {
   const { i18n } = useLingui()
-  const { view } = useAppSelector(selectMines)
+  let { view } = useAppSelector(selectMines)
   const dispatch = useAppDispatch()
   const [content, setContent] = useState<ReactNode>()
+  view = view || MineModalView.Staking as MineModalView // view type looks wrong
 
   return (
     <Context.Provider value={useMemo(() => ({ content, setContent }), [content, setContent])}>


### PR DESCRIPTION
The bug: using an empty wallet and click on Soul staking crashes the app. This is a tailwind bug triggered by an empty popup, which in turn is because the "view" variable has an invalid value.

Solution: set a default valid value for "view". This may be better solved by fixing the underlaying reason for view to be undefined, but in that scenario I'd also leave a default value to prevent this type of hard errors in the future (we could print a warning at the console instead, maybe).