### PR TITLE
fix duplicated events by only rendering 1 liq view (add/remove) + remove advanced button

### DIFF
--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -1,5 +1,5 @@
 import { ChainId, Percent } from '../../sdk'
-import React, { useRef, useState } from 'react'
+import React, { useCallback, useRef, useState } from 'react'
 import { CheckIcon, CogIcon } from '@heroicons/react/outline'
 import {
   useExpertModeManager,
@@ -40,7 +40,7 @@ export default function SettingsTab({ placeholderSlippage }: { placeholderSlippa
   // show confirmation view before turning on
   const [showConfirmation, setShowConfirmation] = useState(false)
 
-  useOnClickOutside(node, open ? toggle : undefined)
+  useOnClickOutside(node, toggle);
 
   const [ttl, setTtl] = useUserTransactionTTL()
 
@@ -70,6 +70,9 @@ export default function SettingsTab({ placeholderSlippage }: { placeholderSlippa
               {i18n._(t`Interface Settings`)}
             </Typography>
 
+            {/*
+              Removing the expert mode as it doesn't work with a modal already opened, and closing the modal doesn't make sense
+
             <div className="flex items-center justify-between">
               <div className="flex items-center">
                 <Typography variant="sm" className="text-primary">
@@ -95,6 +98,7 @@ export default function SettingsTab({ placeholderSlippage }: { placeholderSlippa
                 }
               />
             </div>
+            */}
             <div className="flex items-center justify-between">
               <div className="flex items-center">
                 <Typography variant="sm" className="text-primary">

--- a/src/features/mines/utils/ManageSwapPair.tsx
+++ b/src/features/mines/utils/ManageSwapPair.tsx
@@ -50,12 +50,15 @@ const allowedSlippage = useUserSlippageToleranceWithDefault(DEFAULT_ADD_V2_SLIPP
 
   return (
     <>
-      <div className={classNames(toggle ? 'flex flex-col flex-grow gap-4' : 'hidden')}>
-        <PoolAddLiquidity currencyA={token0} currencyB={token1} header={header} />
-      </div>
-      <div className={classNames(!toggle ? 'flex flex-col flex-grow gap-4' : 'hidden')}>
-        <PoolRemoveLiquidity currencyA={token0} currencyB={token1} header={header} />
-      </div>
+      {toggle ? (
+        <div className={classNames('flex flex-col flex-grow gap-4')}>
+          <PoolAddLiquidity currencyA={token0} currencyB={token1} header={header} />
+        </div>
+      ) : (
+        <div className={classNames('flex flex-col flex-grow gap-4')}>
+          <PoolRemoveLiquidity currencyA={token0} currencyB={token1} header={header} />
+        </div>
+      )}
     </>
   )
 }


### PR DESCRIPTION
After fixing the bug I noticed the "expert mode" switch didn't work too so I commented it, as it doesn't seem that useful anyway, but I can make a follow up PR to exclude it conditionally when there's a modal view, as 2 modals can't be opened at the same time.

Fixes https://github.com/SoulSwapFinance/soul-interface/issues/414