### PR TITLE
More elegant solution to the initial crash when using an empty wallet

### DIFF
--- a/src/features/mines/MineList.tsx
+++ b/src/features/mines/MineList.tsx
@@ -99,7 +99,7 @@ const FarmList = ({ farms, term }) => {
                   setSelectedFarm(farm)
                   dispatch(
                     setMinesModalState({
-                      view: positionIds.includes(farm.id) ? MineModalView.Position : MineModalView.Liquidity,
+                      view: farm.id === "0" || positionIds.includes(farm.id) ? MineModalView.Position : MineModalView.Liquidity,
                       open: true,
                     })
                   )


### PR DESCRIPTION
Instead of working around the undefined view it changes the logic to avoid showing "Liquidity" when opening the staking pool

Fixes #416